### PR TITLE
prevent throwing errors from the command line

### DIFF
--- a/src/old.js
+++ b/src/old.js
@@ -4,6 +4,12 @@ var numPlots = 0;
 
 function print(x) {
 
+  //wpEditor is not present if not run in the browser
+  if (typeof(wpEditor) === 'undefined') { 
+    console.log("viz.print: no wpEditor, not drawing");
+    return;
+  }
+
   // name the plots to keep compatibility with the rest of erin's code
   var _resultDiv = wpEditor.makeResultContainer();
   var resultDiv = $(_resultDiv);


### PR DESCRIPTION
To run examples as tests for agentmodels.org and webppl-gridworld, we occasionally want to call `viz.print` in a script run from the command line. This is needed to prevent errors.
