### PR TITLE
Prevent print from being called when viz.marginals is called from command line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1443,8 +1443,9 @@ function marginals(erp, options) {
       }
 
       // only call print if running in browser
-      if (runningInBrowser())
-          print(field + ":");
+      if (runningInBrowser()) {
+        print(field + ":");
+      }
 
       viz.auto(fauxErp, options)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1442,7 +1442,10 @@ function marginals(erp, options) {
         }
       }
 
-      print(field + ":")
+      // only call print if running in browser
+      if (runningInBrowser())
+          print(field + ":");
+
       viz.auto(fauxErp, options)
     }
   )


### PR DESCRIPTION
Print is only defined when running in browser, but was always called in viz.marginals to label each plot. The plots are unlabeled, but can now be generated without exceptions being thrown.
