### PR TITLE
add support of stroke width option to viz.line

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Methods for plotting raw data.
 - `xLabel` (default: x). x axis label.
 - `yLabel` (default: y). y axis label.
 - `groupBy` (default: none). Grouping variable for different lines.
+- `strokeWidth` (default: 2). The line stroke width, in pixels.
 
 #### Scatter plot
 

--- a/src/index.js
+++ b/src/index.js
@@ -1463,7 +1463,8 @@ function density(x, options) {
 // TODO: show points too
 function line(df, options) {
   options = _.defaults(options || {},
-                       {groupBy: false})
+                       {groupBy: false,
+                        strokeWidth: 2})
 
   var xName = _.keys(df[0])[0];
   var yName = _.keys(df[0])[1];
@@ -1473,6 +1474,9 @@ function line(df, options) {
   var vlSpec = {
     "data": {values: df},
     "mark": "line",
+    "config": {
+      "mark": {"strokeWidth": options.strokeWidth}
+    },
     "encoding": {
       "x": {"field": xName, axis: {title: options.xLabel || xName}, "type": "quantitative"},
       "y": {"field": yName, axis: {title: options.yLabel || yName}, "type": "quantitative"}


### PR DESCRIPTION
It’s crucial for cases when you have a lot of data points with similar
values and then the default stroke-width (2) make the plot unreadable
since its too bold…
Let me know if you have any comments!