### PR TITLE
Use probs in cr and ccr plots.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -310,7 +310,8 @@ kindPrinter.cr = function(args, options) {
                                        var groupWeight = util.sum(_.pluck(states,'prob'));
 
                                        var rValues = _.pluck(states, rDimName);
-                                       var estimates = kde(rValues);
+                                       var probs = _.pluck(states, 'prob');
+                                       var estimates = kde(rValues, {weights: probs});
                                        _.each(estimates, function(est) { est.density *= groupWeight });
                                        return estimates;
                                      });
@@ -439,7 +440,8 @@ kindPrinter.ccr = function(args, options) {
                                        var groupWeight = util.sum(_.pluck(states,'prob'));
 
                                        var rValues = _.pluck(states, rDimName);
-                                       var estimates = kde(rValues);
+                                       var probs = _.pluck(states, 'prob');
+                                       var estimates = kde(rValues, {weights: probs});
                                        _.each(estimates, function(est) { est.density *= groupWeight });
                                        return estimates;
                                      });


### PR DESCRIPTION
I think #83 is caused by not using the score of each value in the support when computing the kde. Looking at the `kindPrinter.r` this seems to be an appropriate fix? I don't know whether similar changes are required elsewhere?