### PR TITLE
Automatically open graphs if process.env.WEBPPL_VIZ_AUTOOPEN is set (resolves #86)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "source-map": "^0.5.6",
     "underscore": "^1.8.3",
     "vega": "^2.6.3",
-    "vega-lite": "^1.2.0"
+    "vega-lite": "^1.2.0",
+    "open": "0.0.5"
   },
   "devDependencies": {
     "aws-sdk": "^2.4.2",
@@ -65,7 +66,6 @@
     "grunt-gjslint": "^0.2.1",
     "grunt-subgrunt": "^1.2.0",
     "jstransform": "^11.0.3",
-    "open": "0.0.5",
     "through": "^2.3.8",
     "watchify": "^3.7.0",
     "webppl": "probmods/webppl#8941a5",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ var d3 = require('d3');
 var $ = require('jquery');
 var dependencyAnalysis = require('./dependency-analysis');
 var reflection = require('./reflection');
+var open = require("open");
 
 global.d3 = d3;
 
@@ -1039,6 +1040,11 @@ function renderSpec(spec, _options) {
 
                     require('fs').writeFileSync(fileName, svgText);
                     console.log("Rendered to " + fileName);
+                    
+                    if(process.env.WEBPPL_VIZ_AUTOOPEN) {
+                        open(fileName);
+                    }
+                    
                     util.trampolineRunners.cli()( options.callback() )
                   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -1036,12 +1036,23 @@ function renderSpec(spec, _options) {
                   function(error, chart) {
                     var view = chart({renderer: 'svg'}).update();
                     var svgText = view.svg();
-                    var fileName = options.fileName || (md5(svgText).substring(0,7) + '.svg');
+                    
+                    var now = new Date();
+                    var str = now.getUTCFullYear().toString() + "_" +
+                            (now.getUTCMonth() + 1).toString() + "_" +
+                            now.getUTCDate() + "_" +
+                            now.getUTCHours() + "_" +
+                            now.getUTCMinutes() + "_" +
+                            now.getUTCSeconds() + "_" +
+                            now.getMiliseconds;
+                            
+                    var fileName = options.fileName || str + '.svg');
 
                     require('fs').writeFileSync(fileName, svgText);
                     console.log("Rendered to " + fileName);
                     
                     if(process.env.WEBPPL_VIZ_AUTOOPEN) {
+                        
                         open(fileName);
                     }
                     

--- a/src/index.js
+++ b/src/index.js
@@ -1043,10 +1043,13 @@ function renderSpec(spec, _options) {
                             now.getUTCDate() + "_" +
                             now.getUTCHours() + "_" +
                             now.getUTCMinutes() + "_" +
-                            now.getUTCSeconds() + "_" +
-                            now.getMilliseconds();
+                            now.getUTCSeconds();
                             
-                    var fileName = options.fileName || str + '.svg');
+                    var fileName = options.fileName || str + '.svg';
+                    
+                    if (fs.existsSync(fileName)) {
+                        fileName += "_" + now.getMilliseconds();
+                    }
 
                     require('fs').writeFileSync(fileName, svgText);
                     console.log("Rendered to " + fileName);

--- a/src/index.js
+++ b/src/index.js
@@ -1044,7 +1044,7 @@ function renderSpec(spec, _options) {
                             now.getUTCHours() + "_" +
                             now.getUTCMinutes() + "_" +
                             now.getUTCSeconds() + "_" +
-                            now.getMiliseconds;
+                            now.getMilliseconds();
                             
                     var fileName = options.fileName || str + '.svg');
 


### PR DESCRIPTION
You have to run `export WEBPPL_VIZ_AUTOOPEN="true"` for this to work.
Resolves bug #86 