### PR TITLE
fix unresolved fs call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ var $ = require('jquery');
 var dependencyAnalysis = require('./dependency-analysis');
 var reflection = require('./reflection');
 var open = require("open");
-
+var fs = require('fs');
 global.d3 = d3;
 
 var vl = require('vega-lite');
@@ -1051,7 +1051,7 @@ function renderSpec(spec, _options) {
                         fileName += "_" + now.getMilliseconds();
                     }
 
-                    require('fs').writeFileSync(fileName, svgText);
+                    fs.writeFileSync(fileName, svgText);
                     console.log("Rendered to " + fileName);
                     
                     if(process.env.WEBPPL_VIZ_AUTOOPEN) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ var $ = require('jquery');
 var dependencyAnalysis = require('./dependency-analysis');
 var reflection = require('./reflection');
 var open = require("open");
-var fs = require('fs');
 global.d3 = d3;
 
 var vl = require('vega-lite');
@@ -1047,11 +1046,12 @@ function renderSpec(spec, _options) {
                             
                     var fileName = options.fileName || str + '.svg';
                     
-                    if (fs.existsSync(fileName)) {
-                        fileName += "_" + now.getMilliseconds();
+                    if (require('fs').existsSync(fileName)) {
+                        fileName = fileName.replace('.svg','');
+                        fileName += "_" + now.getMilliseconds() + '.svg';
                     }
 
-                    fs.writeFileSync(fileName, svgText);
+                    require('fs').writeFileSync(fileName, svgText);
                     console.log("Rendered to " + fileName);
                     
                     if(process.env.WEBPPL_VIZ_AUTOOPEN) {


### PR DESCRIPTION
As an addition to pull request #87 and advice of @longouyang againt globally requiring fs, this is a small edit, which directly requires fs, which fixes the problem with the `if (fs.existsSync(fileName))` call (line 1050), where fs was previously not resolved (as there was no such symbol defined in the global scope). 
Additionally, I fixed renaming logic in the case the file already exists, so e.g. no  "....svg_213" will be created but "..._213.svg" as intended.